### PR TITLE
fix: add hover tooltip for Cookie Policy in footer

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -152,6 +152,11 @@ const Footer = () => {
               <a className="group relative hover:text-white transition-colors duration-300">
                 <span className="relative z-10">Cookie Policy</span>
                 <div className="absolute inset-0 bg-gradient-to-r from-primary-600/20 to-purple-600/20 rounded-lg opacity-0 group-hover:opacity-100 transition-opacity duration-300 -inset-2"></div>
+                <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-3 w-72 bg-gray-900 border border-gray-700 rounded-xl p-4 text-xs text-gray-300 leading-relaxed opacity-0 group-hover:opacity-100 transition-opacity duration-300 pointer-events-none z-50 shadow-xl">
+                  <p className="font-semibold text-white mb-1">Cookie Policy</p>
+                  <p>We use cookies to enhance your browsing experience, analyze site traffic, and personalize content. By using JobPortal, you consent to our use of cookies. You can manage your cookie preferences through your browser settings at any time.</p>
+                  <div className="absolute top-full left-1/2 -translate-x-1/2 border-4 border-transparent border-t-gray-700"></div>
+                </div>
               </a>
               <Link
                 to="/contact"


### PR DESCRIPTION
## Summary

- Added a Tailwind CSS hover tooltip to the **Cookie Policy** link in the footer
- Tooltip displays a brief cookie policy description when the user hovers over the link
- Tooltip uses an arrow indicator pointing down toward the link for clear visual context

Closes #2

## Test plan

- [ ] Hover over "Cookie Policy" in the footer — tooltip with cookie policy text should appear above the link
- [ ] Verify tooltip disappears when mouse leaves
- [ ] Check tooltip positioning on different screen sizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)