### PR TITLE
fix: add hover tooltip for Privacy Policy in footer

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -144,6 +144,11 @@ const Footer = () => {
               <a className="group relative hover:text-white transition-colors duration-300">
                 <span className="relative z-10">Privacy Policy</span>
                 <div className="absolute inset-0 bg-gradient-to-r from-primary-600/20 to-purple-600/20 rounded-lg opacity-0 group-hover:opacity-100 transition-opacity duration-300 -inset-2"></div>
+                <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-3 w-72 bg-gray-900 border border-gray-700 rounded-xl p-4 text-xs text-gray-300 leading-relaxed opacity-0 group-hover:opacity-100 transition-opacity duration-300 pointer-events-none z-50 shadow-xl">
+                  <p className="font-semibold text-white mb-1">Privacy Policy</p>
+                  <p>We are committed to protecting your privacy. JobPortal collects only the information necessary to provide our services, including your name, email, and job preferences. We never sell your personal data to third parties. For full details, please review our complete privacy policy.</p>
+                  <div className="absolute top-full left-1/2 -translate-x-1/2 border-4 border-transparent border-t-gray-700"></div>
+                </div>
               </a>
               <a className="group relative hover:text-white transition-colors duration-300">
                 <span className="relative z-10">Terms of Service</span>


### PR DESCRIPTION
## Summary
- Added a hover tooltip to the Privacy Policy link in the footer
- Tooltip displays a brief privacy policy summary on hover, consistent with the existing Cookie Policy tooltip

Fixes #5

## Test plan
- [ ] Hover over "Privacy Policy" in the footer — tooltip should appear with privacy policy text
- [ ] Verify tooltip disappears when not hovering
- [ ] Confirm Cookie Policy tooltip still works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)