### PR TITLE
fix: add hover tooltip for Terms of Service in footer

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -148,6 +148,11 @@ const Footer = () => {
               <a className="group relative hover:text-white transition-colors duration-300">
                 <span className="relative z-10">Terms of Service</span>
                 <div className="absolute inset-0 bg-gradient-to-r from-primary-600/20 to-purple-600/20 rounded-lg opacity-0 group-hover:opacity-100 transition-opacity duration-300 -inset-2"></div>
+                <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-3 w-72 bg-gray-900 border border-gray-700 rounded-xl p-4 text-xs text-gray-300 leading-relaxed opacity-0 group-hover:opacity-100 transition-opacity duration-300 pointer-events-none z-50 shadow-xl">
+                  <p className="font-semibold text-white mb-1">Terms of Service</p>
+                  <p>By using JobPortal, you agree to our terms governing your use of the platform, including job postings, applications, and account management. We reserve the right to update these terms at any time. Continued use of the service constitutes acceptance of the updated terms.</p>
+                  <div className="absolute top-full left-1/2 -translate-x-1/2 border-4 border-transparent border-t-gray-700"></div>
+                </div>
               </a>
               <a className="group relative hover:text-white transition-colors duration-300">
                 <span className="relative z-10">Cookie Policy</span>


### PR DESCRIPTION
## Summary
- Added a hover tooltip to the **Terms of Service** link in the footer, matching the existing Cookie Policy tooltip pattern
- Tooltip appears above the link on hover with a title, description text, and downward arrow indicator

## Test plan
- [ ] Hover over "Terms of Service" in the footer — tooltip should appear above it
- [ ] Verify tooltip styling matches the Cookie Policy tooltip (same dimensions, colors, arrow)
- [ ] Verify tooltip disappears when mouse leaves the link

🤖 Generated with [Claude Code](https://claude.com/claude-code)