### PR TITLE
fix: add hover tooltip text to Contact Us link in footer

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -174,6 +174,11 @@ const Footer = () => {
               >
                 <span className="relative z-10">Contact Us</span>
                 <div className="absolute inset-0 bg-gradient-to-r from-primary-600/20 to-purple-600/20 rounded-lg opacity-0 group-hover:opacity-100 transition-opacity duration-300 -inset-2"></div>
+                <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-3 w-72 bg-gray-900 border border-gray-700 rounded-xl p-4 text-xs text-gray-300 leading-relaxed opacity-0 group-hover:opacity-100 transition-opacity duration-300 pointer-events-none z-50 shadow-xl">
+                  <p className="font-semibold text-white mb-1">Contact Us</p>
+                  <p>Have a question or need assistance? Reach out to our support team through the contact page. You can send us a message about any issues you are facing, and we will get back to you as soon as possible.</p>
+                  <div className="absolute top-full left-1/2 -translate-x-1/2 border-4 border-transparent border-t-gray-700"></div>
+                </div>
               </Link>
             </div>
             <div className="text-center md:text-right">


### PR DESCRIPTION
Add missing hover tooltip to the "Contact Us" link in the footer. The other footer links (Privacy Policy, Terms of Service, Cookie Policy) all had tooltip popups on hover, but Contact Us was missing one.

Fixes #9

Generated with [Claude Code](https://claude.ai/code)